### PR TITLE
Fix Linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Create dialogs, characters and scenes to display conversations in your Godot games. 
 
-[Changelog](https://github.com/coppolaemilio/dialogic/blob/dialogic-1/addons/dialogic/Documentation/Content/Changelog.md) — 
+[Changelog](./addons/dialogic/Documentation/Content/Changelog.md) — 
 [Installation](#installation) — 
-[Documentation](https://github.com/coppolaemilio/dialogic/blob/dialogic-1/addons/dialogic/Documentation/Content/Welcome.md) — 
+[Documentation](./addons/dialogic/Documentation/Content/Welcome.md) — 
 [Credits](#credits)
 
 
@@ -21,21 +21,21 @@ Create dialogs, characters and scenes to display conversations in your Godot gam
 -----
 ## Getting started
 
-You can read a step by step guide on how to use [Dialogic here](https://github.com/coppolaemilio/dialogic/blob/dialogic-1/addons/dialogic/Documentation/Content/Tutorials/BeginnersGuideStepByStep.md)
+You can read a step by step guide on how to use [Dialogic here](./addons/dialogic/Documentation/Content/Tutorials/BeginnersGuideStepByStep.md)
 
 ## 📚 Documentation
-You can check the documentation from inside the plugin or [here](https://github.com/coppolaemilio/dialogic/blob/dialogic-1/addons/dialogic/Documentation/Content/Welcome.md)
+You can check the documentation from inside the plugin or [here](./addons/dialogic/Documentation/Content/Welcome.md)
 
 ## Installation
 
-To install a Dialogic, download it as a ZIP archive. All releases are listed here: [releases](https://github.com/coppolaemilio/dialogic/releases). Then extract the ZIP archive and move the `addons/` folder it contains into your project folder. Then, enable the plugin in project settings.
+To install a Dialogic, download it as a ZIP archive. All releases are listed here: [releases](https://github.com/dialogic-godot/dialogic/releases). Then extract the ZIP archive and move the `addons/` folder it contains into your project folder. Then, enable the plugin in project settings.
 
 If you want to know more about installing plugins you can read the [Godot docs page](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/installing_plugins.html).
 
 You can also install Dialogic using the **AssetLib** tab in the editor, but the version here will not be the latest one available since it takes some time for it to be approved.
 
 ## ⚠ IMPORTANT
-There has been some people having issues exporting their games. If you are having issues you can try to add `*.cfg` and `*.json` to your export settings [(image)](https://coppolaemilio.com/images/dialogic/exporting-2.png). If it is not that, try having at least 1 theme in your project. If you still have issues, please [open an issue](https://github.com/coppolaemilio/dialogic/issues).
+There has been some people having issues exporting their games. If you are having issues you can try to add `*.cfg` and `*.json` to your export settings. If it is not that, try having at least 1 theme in your project. If you still have issues, please [open an issue](https://github.com/dialogic-godot/dialogic-1/issues).
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can check the documentation from inside the plugin or [here](./addons/dialog
 
 To install a Dialogic, download it as a ZIP archive. All releases are listed here: [releases](https://github.com/dialogic-godot/dialogic/releases). Then extract the ZIP archive and move the `addons/` folder it contains into your project folder. Then, enable the plugin in project settings.
 
-If you want to know more about installing plugins you can read the [Godot docs page](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/installing_plugins.html).
+If you want to know more about installing plugins you can read the [Godot docs page](https://docs.godotengine.org/en/3.5/tutorials/plugins/editor/installing_plugins.html).
 
 You can also install Dialogic using the **AssetLib** tab in the editor, but the version here will not be the latest one available since it takes some time for it to be approved.
 

--- a/addons/dialogic/Documentation/Content/Changelog.md
+++ b/addons/dialogic/Documentation/Content/Changelog.md
@@ -4,13 +4,13 @@
 
 ## v1.5.1
 * Fixed a bug that prevented directories from being created on Android exports [[WolfgangSenff](https://github.com/WolfgangSenff)]
-* Fixed a bug [#1935](https://github.com/coppolaemilio/dialogic/issues/1935) where the creation buttons wouldn't function if a folder wasn't selected first [[zaknafean](https://github.com/zaknafean)]
-* Fixed a bug [#1644](https://github.com/coppolaemilio/dialogic/issues/1644) and [#1343](https://github.com/coppolaemilio/dialogic/issues/1343) where character leaves history logging could not be disabled.
+* Fixed a bug [#1935](https://github.com/dialogic-godot/dialogic/issues/1935) where the creation buttons wouldn't function if a folder wasn't selected first [[zaknafean](https://github.com/zaknafean)]
+* Fixed a bug [#1644](https://github.com/dialogic-godot/dialogic/issues/1644) and [#1343](https://github.com/dialogic-godot/dialogic/issues/1343) where character leaves history logging could not be disabled.
 * Themes can now properly duplicate
 * Choice button styles no longer 'randomly' revert
-* Commands will no longer show up in the history screen [#1709](https://github.com/coppolaemilio/dialogic/issues/1709)
-* Unused 'random text' will no longer show up in the history screen [#1710](https://github.com/coppolaemilio/dialogic/issues/1710)
-* Goto Anchors (labels) are now uniquely ID'd [#1119](https://github.com/coppolaemilio/dialogic/issues/1119). If you have labels that do not show up in your goto event, just hit the 'regenerate' button ![image](https://github.com/coppolaemilio/dialogic/assets/7741797/4c9c50c4-4a4d-4f56-b4f4-f90e1c4cd19c)
+* Commands will no longer show up in the history screen [#1709](https://github.com/dialogic-godot/dialogic/issues/1709)
+* Unused 'random text' will no longer show up in the history screen [#1710](https://github.com/dialogic-godot/dialogic/issues/1710)
+* Goto Anchors (labels) are now uniquely ID'd [#1119](https://github.com/dialogic-godot/dialogic/issues/1119). If you have labels that do not show up in your goto event, just hit the 'regenerate' button ![image](https://github.com/dialogic-godot/dialogic/assets/7741797/4c9c50c4-4a4d-4f56-b4f4-f90e1c4cd19c)
 * Fixed a bug that broke PCK encrypted games using Dialogic. [[TheMeddlingMechanic](https://github.com/TheMeddlingMechanic)]
 
 
@@ -35,7 +35,7 @@
 ## v1.4.4
 * Added no skip event [[zaknafean](https://github.com/zaknafean)]
 * Added auto-advance mode [[zaknafean](https://github.com/zaknafean)]
-* Translation Service Speed fixes by [[thebardsrc](https://github.com/thebardsrc)] in https://github.com/coppolaemilio/dialogic/pull/995
+* Translation Service Speed fixes by [[thebardsrc](https://github.com/thebardsrc)] in https://github.com/dialogic-godot/dialogic/pull/995
 * Fixed some Anima bugs [[zaknafean](https://github.com/zaknafean)]
 
 ## v1.4.3 
@@ -43,18 +43,18 @@
 The biggest changes in this version are fixes to a bug when exporting the games. Thank you everyone!
 
 ## What's Changed
-* Update Chinese Translation by @magian1127 in https://github.com/coppolaemilio/dialogic/pull/920
-* 1.4: Added simple slide_in character entrance animations by @champbob in https://github.com/coppolaemilio/dialogic/pull/945
-* 1.4: Added simple slide_out character entrance animations by @champbob in https://github.com/coppolaemilio/dialogic/pull/946
-* Fix multi-line code by @lemon37564 in https://github.com/coppolaemilio/dialogic/pull/970
-* 1.4.3 - Fix for export error due to settings theme failure by @zaknafean in https://github.com/coppolaemilio/dialogic/pull/978
-* 1.4.3 - Fix for #904 by @zaknafean in https://github.com/coppolaemilio/dialogic/pull/979
+* Update Chinese Translation by @magian1127 in https://github.com/dialogic-godot/dialogic/pull/920
+* 1.4: Added simple slide_in character entrance animations by @champbob in https://github.com/dialogic-godot/dialogic/pull/945
+* 1.4: Added simple slide_out character entrance animations by @champbob in https://github.com/dialogic-godot/dialogic/pull/946
+* Fix multi-line code by @lemon37564 in https://github.com/dialogic-godot/dialogic/pull/970
+* 1.4.3 - Fix for export error due to settings theme failure by @zaknafean in https://github.com/dialogic-godot/dialogic/pull/978
+* 1.4.3 - Fix for #904 by @zaknafean in https://github.com/dialogic-godot/dialogic/pull/979
 
 ## New Contributors
-* @champbob made their first contribution in https://github.com/coppolaemilio/dialogic/pull/945
-* @lemon37564 made their first contribution in https://github.com/coppolaemilio/dialogic/pull/970
+* @champbob made their first contribution in https://github.com/dialogic-godot/dialogic/pull/945
+* @lemon37564 made their first contribution in https://github.com/dialogic-godot/dialogic/pull/970
 
-**Full Changelog**: https://github.com/coppolaemilio/dialogic/compare/1.4.2...1.4.3
+**Full Changelog**: https://github.com/dialogic-godot/dialogic/compare/1.4.2...1.4.3
 
 ## v1.4.2 - Afterlife
 - Fixed an issue with MacOS and text events not adjusting their size properly
@@ -239,7 +239,7 @@ The biggest changes in this version are fixes to a bug when exporting the games.
 - Fixed some issues with the `[nw]` command [[Jowan-Spooner](https://github.com/Jowan-Spooner)]
 - Improved the Timeline Editor performance when loading timelines
 - Removed the `focus_mode` warning
-- Added a new page to the docs about the [Text Events](https://github.com/coppolaemilio/dialogic/blob/main/docs/events/TextEvent.md)
+- Added a new page to the docs about the [Text Events](https://github.com/dialogic-godot/dialogic/blob/main/docs/events/TextEvent.md)
 - Fixed a bug when trying to skip fade-in dialog animations [[idontkillcoyotes](https://github.com/idontkillcoyotes)]
 - Fixed an issue with typing sounds in exported projects
 - Fixed an issue when selecting folders for typing sounds in exporting projects; Thank you [AnidemDex](https://github.com/AnidemDex)!
@@ -366,7 +366,7 @@ The biggest changes in this version are fixes to a bug when exporting the games.
 - Added a button in timeline inspector plugin to open the selected timeline in the editor [[ellogwen](https://github.com/ellogwen)]
 - Special thanks to [Jowan-Spooner](https://github.com/Jowan-Spooner) for the QA and the facelift on the theme editor
 
-To view previous changes [click here](https://github.com/coppolaemilio/dialogic/blob/main/CHANGELOG.md). 
+To view previous changes [click here](https://github.com/dialogic-godot/dialogic/blob/main/CHANGELOG.md). 
 
 
 ## v1.0 - We made it! 🎉

--- a/addons/dialogic/Documentation/Content/Events/002.md
+++ b/addons/dialogic/Documentation/Content/Events/002.md
@@ -23,4 +23,4 @@ In this mode you can alternatively select the `All characters` option to make al
 ![Event](./Images/Event_Character_Update.PNG)
 The update settings has all the options of the join mode, but you can enable (pen icon) and disable (reset icon) each of them. Also there are other animations and you can choose to `repeat` the animation a number of times. 
 
-If you want to know more about animations you can [read about them here](https://github.com/coppolaemilio/dialogic/blob/main/addons/dialogic/Documentation/Content/Tutorials/AddingNewAnimations.md).
+If you want to know more about animations you can [read about them here](./addons/dialogic/Documentation/Content/Tutorials/AddingNewAnimations.md).

--- a/addons/dialogic/Documentation/Content/Events/040.md
+++ b/addons/dialogic/Documentation/Content/Events/040.md
@@ -20,4 +20,4 @@ func dialog_listener(string):
 
 If you instanced the scene using the editor, you can connect the signal like normal in Godot from the `NODE TAB > Signals`.
 
-*If you don't know about signals you should definitely learn about them. For example [here](https://docs.godotengine.org/en/stable/getting_started/step_by_step/signals.html).*
+*If you don't know about signals you should definitely learn about them. For example [here](https://docs.godotengine.org/en/3.5/getting_started/step_by_step/signals.html).*

--- a/addons/dialogic/Documentation/Content/Welcome.md
+++ b/addons/dialogic/Documentation/Content/Welcome.md
@@ -1,7 +1,7 @@
 ![WelcomeImage](./Images/dialogic-hero-1.3.png)
 Welcome to the help pages. Here you can find all the information available on how to use the plugin and its parts.  
 
-If you are looking for something specific, you can use the filter in the upper left. If you need extra help you can ask questions here: [GitHub Discussions](https://github.com/coppolaemilio/dialogic/discussions) or alternatively chat about the development of Dialogic on [Emilio's Discord server](https://discord.gg/v4zhZNh)!
+If you are looking for something specific, you can use the filter in the upper left. If you need extra help you can ask questions here: [GitHub Discussions](https://github.com/dialogic-godot/dialogic/discussions) or alternatively chat about the development of Dialogic on [Emilio's Discord server](https://discord.gg/v4zhZNh)!
 
 This project is made possible by the support of our [Patreons](https://www.patreon.com/coppolaemilio) and Github Sponsors.
 


### PR DESCRIPTION
There are multiple small linking issues where the markdown documents have permanent links to pages which no longer exist, this PR simply (hopefully) fixes all those links so that people can get where they want to go