### PR TITLE
Improve stuttering when starting a timeline

### DIFF
--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
@@ -9,7 +9,7 @@ onready var nodes = {
 	'canvas_layer' : $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer/HBoxContainer3/CanvasLayer,
 	
 	# Dialog
-	'preload_node_button' : $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer/Button,
+	'cached_node_button' : $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer/Button,
 	'text_event_audio_default_bus' : $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/TextAudioDefaultBus/AudioBus,
 
 	# Input Settings
@@ -112,8 +112,8 @@ func _ready():
 		nodes[key].connect('pressed', self, '_on_hotkey_action_key_presssed', [key])
 		nodes[key].connect('item_selected', self, '_on_default_action_key_item_selected', [key])
 	
-	nodes['preload_node_button'].connect('pressed', self, '_on_preload_node_button_pressed')
-	_update_preloaded_node_name(settings.get_value('dialog', 'preload_node', "res://addons/dialogic/Nodes/DialogNode.tscn"))
+	nodes['cached_node_button'].connect('pressed', self, '_on_cached_node_button_pressed')
+	_update_cached_node_name(settings.get_value('dialog', 'cached_dialognode', "res://addons/dialogic/Nodes/DialogNode.tscn"))
 	AudioServer.connect("bus_layout_changed", self, "update_bus_selector")
 	nodes['text_event_audio_default_bus'].connect('item_selected', self, '_on_text_audio_default_bus_item_selected')
 	
@@ -280,19 +280,19 @@ func _on_text_changed(text, section: String, key: String) -> void:
 	#set_value('history', 'history_character_delimiter', text)
 
 
-func _on_preload_node_button_pressed():
+func _on_cached_node_button_pressed():
 	editor_reference.godot_dialog("*.tscn")
-	editor_reference.godot_dialog_connect(self, "_on_preload_node_selected")
+	editor_reference.godot_dialog_connect(self, "_on_cached_node_selected")
 
 
-func _on_preload_node_selected(path, _target):
-	set_value('dialog', 'preload_node', path)
-	_update_preloaded_node_name(path)
+func _on_cached_node_selected(path, _target):
+	set_value('dialog', 'cached_node', path)
+	_update_cached_node_name(path)
 
 
-func _update_preloaded_node_name(path : String):
+func _update_cached_node_name(path : String):
 	var name = path.get_file()
-	nodes['preload_node_button'].text = name
+	nodes['cached_node_button'].text = name
 
 
 # Reading and saving data to the settings file

--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
@@ -9,6 +9,7 @@ onready var nodes = {
 	'canvas_layer' : $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer/HBoxContainer3/CanvasLayer,
 	
 	# Dialog
+	'preload_node_button' : $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer/Button,
 	'text_event_audio_default_bus' : $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/TextAudioDefaultBus/AudioBus,
 
 	# Input Settings
@@ -89,6 +90,7 @@ var ANIMATION_KEYS := [
 
 func _ready():
 	editor_reference = find_parent('EditorView')
+	var settings = DialogicResources.get_settings_config()
 	update_bus_selector()
 	
 	update_data()
@@ -110,6 +112,8 @@ func _ready():
 		nodes[key].connect('pressed', self, '_on_hotkey_action_key_presssed', [key])
 		nodes[key].connect('item_selected', self, '_on_default_action_key_item_selected', [key])
 	
+	nodes['preload_node_button'].connect('pressed', self, '_on_preload_node_button_pressed')
+	_update_preloaded_node_name(settings.get_value('dialog', 'preload_node', "res://addons/dialogic/Nodes/DialogNode.tscn"))
 	AudioServer.connect("bus_layout_changed", self, "update_bus_selector")
 	nodes['text_event_audio_default_bus'].connect('item_selected', self, '_on_text_audio_default_bus_item_selected')
 	
@@ -274,6 +278,21 @@ func _on_canvas_layer_text_changed(text) -> void:
 func _on_text_changed(text, section: String, key: String) -> void:
 	set_value(section, key, text)
 	#set_value('history', 'history_character_delimiter', text)
+
+
+func _on_preload_node_button_pressed():
+	editor_reference.godot_dialog("*.tscn")
+	editor_reference.godot_dialog_connect(self, "_on_preload_node_selected")
+
+
+func _on_preload_node_selected(path, _target):
+	set_value('dialog', 'preload_node', path)
+	_update_preloaded_node_name(path)
+
+
+func _update_preloaded_node_name(path : String):
+	var name = path.get_file()
+	nodes['preload_node_button'].text = name
 
 
 # Reading and saving data to the settings file

--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
@@ -9,7 +9,7 @@
 [ext_resource path="res://addons/dialogic/Editor/Events/styles/InputFieldsStyle.tres" type="Theme" id=7]
 [ext_resource path="res://addons/dialogic/Editor/SettingsEditor/Scenes/TranslationIDSettings.tscn" type="PackedScene" id=8]
 
-[sub_resource type="Image" id=1]
+[sub_resource type="Image" id=3]
 data = {
 "data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
 "format": "LumAlpha8",
@@ -21,7 +21,7 @@ data = {
 [sub_resource type="ImageTexture" id=2]
 flags = 4
 flags = 4
-image = SubResource( 1 )
+image = SubResource( 3 )
 size = Vector2( 16, 16 )
 
 [node name="SettingsEditor" type="ScrollContainer"]
@@ -32,17 +32,17 @@ script = ExtResource( 1 )
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 margin_right = 1012.0
-margin_bottom = 634.0
+margin_bottom = 662.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer"]
 margin_right = 1012.0
-margin_bottom = 634.0
+margin_bottom = 662.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3"]
 margin_right = 398.0
-margin_bottom = 634.0
+margin_bottom = 662.0
 custom_constants/separation = 16
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
@@ -70,9 +70,9 @@ text_key = "Default"
 
 [node name="ThemePicker" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource( 6 )]
 margin_left = 102.0
-margin_right = 251.0
+margin_right = 306.0
 custom_colors/font_color = Color( 0.8, 0.807843, 0.827451, 1 )
-text = "Default Theme"
+text = "theme-1722543427.cfg"
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer"]
 margin_top = 54.0
@@ -100,7 +100,7 @@ rounded = true
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
 margin_top = 94.0
 margin_right = 398.0
-margin_bottom = 474.0
+margin_bottom = 502.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 2 )]
 margin_right = 398.0
@@ -154,20 +154,30 @@ default = true
 settings_section = "dialog"
 settings_key = "recenter_portrait"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
+[node name="SettingsCheckbox9" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
 margin_top = 166.0
 margin_right = 398.0
 margin_bottom = 190.0
+hint_tooltip = "Re-center portrait on each change (1.4+ behavior)"
+text = "Multithreaded image loading"
+default = true
+settings_section = "dialog"
+settings_key = "threading_enabled"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
+margin_top = 194.0
+margin_right = 398.0
+margin_bottom = 218.0
 
 [node name="SettingsCheckbox9" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer" instance=ExtResource( 4 )]
 margin_right = 262.0
 margin_bottom = 24.0
 hint_tooltip = "Re-center portrait on each change (1.4+ behavior)"
 size_flags_stretch_ratio = 6.0
-text = "Preload DialogNode"
+text = "Cache DialogNode"
 default = true
 settings_section = "dialog"
-settings_key = "do_preload_node"
+settings_key = "do_cache_dialognode"
 
 [node name="Button" type="Button" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer"]
 margin_left = 266.0
@@ -178,31 +188,31 @@ size_flags_stretch_ratio = 3.0
 text = "DialogNode.tscn"
 
 [node name="HSeparator2" type="HSeparator" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
-margin_top = 194.0
+margin_top = 222.0
 margin_right = 398.0
-margin_bottom = 198.0
+margin_bottom = 226.0
 
 [node name="TLabel6" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_top = 202.0
+margin_top = 230.0
 margin_right = 398.0
-margin_bottom = 216.0
+margin_bottom = 244.0
 text = "Audio for Text events:"
 text_key = "Audio for Text events:"
 
 [node name="SettingsCheckbox6" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
-margin_top = 220.0
+margin_top = 248.0
 margin_right = 398.0
-margin_bottom = 244.0
+margin_bottom = 272.0
 text = "Enable audio for Text events"
 settings_section = "dialog"
 settings_key = "text_event_audio_enable"
 
 [node name="TextAudioDefaultBus" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
-margin_top = 248.0
+margin_top = 276.0
 margin_right = 398.0
-margin_bottom = 268.0
+margin_bottom = 296.0
 
 [node name="TLabel8" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/TextAudioDefaultBus" instance=ExtResource( 3 )]
 anchor_right = 0.0
@@ -222,23 +232,23 @@ items = [ "Master", null, false, 0, null ]
 selected = 0
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
-margin_top = 272.0
+margin_top = 300.0
 margin_right = 398.0
-margin_bottom = 276.0
+margin_bottom = 304.0
 
 [node name="TLabel9" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_top = 280.0
+margin_top = 308.0
 margin_right = 398.0
-margin_bottom = 294.0
+margin_bottom = 322.0
 text = "Experimental Translations:"
 text_key = "Experimental Translations:"
 
 [node name="SettingsCheckbox7" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
-margin_top = 298.0
+margin_top = 326.0
 margin_right = 398.0
-margin_bottom = 322.0
+margin_bottom = 350.0
 text = "Inputs for text events will be treated as keys for tr()"
 settings_section = "dialog"
 settings_key = "translations"
@@ -246,14 +256,14 @@ settings_key = "translations"
 [node name="TranslationIdSettings" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 8 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_top = 326.0
+margin_top = 354.0
 margin_right = 398.0
-margin_bottom = 380.0
+margin_bottom = 408.0
 
 [node name="VBoxContainer3" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
-margin_top = 490.0
+margin_top = 518.0
 margin_right = 398.0
-margin_bottom = 540.0
+margin_bottom = 568.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer3" instance=ExtResource( 2 )]
 margin_right = 398.0
@@ -270,9 +280,9 @@ settings_section = "saving"
 settings_key = "autosave"
 
 [node name="VBoxContainer4" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
-margin_top = 556.0
+margin_top = 584.0
 margin_right = 398.0
-margin_bottom = 634.0
+margin_bottom = 662.0
 
 [node name="SectionTitle2" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4" instance=ExtResource( 2 )]
 margin_right = 398.0
@@ -338,7 +348,7 @@ value = 0.5
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3"]
 margin_left = 402.0
 margin_right = 708.0
-margin_bottom = 634.0
+margin_bottom = 662.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2"]
 margin_right = 306.0

--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
@@ -9,7 +9,7 @@
 [ext_resource path="res://addons/dialogic/Editor/Events/styles/InputFieldsStyle.tres" type="Theme" id=7]
 [ext_resource path="res://addons/dialogic/Editor/SettingsEditor/Scenes/TranslationIDSettings.tscn" type="PackedScene" id=8]
 
-[sub_resource type="Image" id=3]
+[sub_resource type="Image" id=1]
 data = {
 "data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
 "format": "LumAlpha8",
@@ -21,7 +21,7 @@ data = {
 [sub_resource type="ImageTexture" id=2]
 flags = 4
 flags = 4
-image = SubResource( 3 )
+image = SubResource( 1 )
 size = Vector2( 16, 16 )
 
 [node name="SettingsEditor" type="ScrollContainer"]
@@ -32,17 +32,17 @@ script = ExtResource( 1 )
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 margin_right = 1012.0
-margin_bottom = 606.0
+margin_bottom = 634.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer"]
 margin_right = 1012.0
-margin_bottom = 606.0
+margin_bottom = 634.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3"]
 margin_right = 398.0
-margin_bottom = 606.0
+margin_bottom = 634.0
 custom_constants/separation = 16
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
@@ -100,7 +100,7 @@ rounded = true
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
 margin_top = 94.0
 margin_right = 398.0
-margin_bottom = 446.0
+margin_bottom = 474.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 2 )]
 margin_right = 398.0
@@ -154,32 +154,55 @@ default = true
 settings_section = "dialog"
 settings_key = "recenter_portrait"
 
-[node name="HSeparator2" type="HSeparator" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
 margin_top = 166.0
 margin_right = 398.0
-margin_bottom = 170.0
+margin_bottom = 190.0
+
+[node name="SettingsCheckbox9" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer" instance=ExtResource( 4 )]
+margin_right = 262.0
+margin_bottom = 24.0
+hint_tooltip = "Re-center portrait on each change (1.4+ behavior)"
+size_flags_stretch_ratio = 6.0
+text = "Preload DialogNode"
+default = true
+settings_section = "dialog"
+settings_key = "do_preload_node"
+
+[node name="Button" type="Button" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer"]
+margin_left = 266.0
+margin_right = 398.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 3.0
+text = "DialogNode.tscn"
+
+[node name="HSeparator2" type="HSeparator" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
+margin_top = 194.0
+margin_right = 398.0
+margin_bottom = 198.0
 
 [node name="TLabel6" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_top = 174.0
+margin_top = 202.0
 margin_right = 398.0
-margin_bottom = 188.0
+margin_bottom = 216.0
 text = "Audio for Text events:"
 text_key = "Audio for Text events:"
 
 [node name="SettingsCheckbox6" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
-margin_top = 192.0
+margin_top = 220.0
 margin_right = 398.0
-margin_bottom = 216.0
+margin_bottom = 244.0
 text = "Enable audio for Text events"
 settings_section = "dialog"
 settings_key = "text_event_audio_enable"
 
 [node name="TextAudioDefaultBus" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
-margin_top = 220.0
+margin_top = 248.0
 margin_right = 398.0
-margin_bottom = 240.0
+margin_bottom = 268.0
 
 [node name="TLabel8" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/TextAudioDefaultBus" instance=ExtResource( 3 )]
 anchor_right = 0.0
@@ -199,23 +222,23 @@ items = [ "Master", null, false, 0, null ]
 selected = 0
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
-margin_top = 244.0
+margin_top = 272.0
 margin_right = 398.0
-margin_bottom = 248.0
+margin_bottom = 276.0
 
 [node name="TLabel9" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_top = 252.0
+margin_top = 280.0
 margin_right = 398.0
-margin_bottom = 266.0
+margin_bottom = 294.0
 text = "Experimental Translations:"
 text_key = "Experimental Translations:"
 
 [node name="SettingsCheckbox7" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
-margin_top = 270.0
+margin_top = 298.0
 margin_right = 398.0
-margin_bottom = 294.0
+margin_bottom = 322.0
 text = "Inputs for text events will be treated as keys for tr()"
 settings_section = "dialog"
 settings_key = "translations"
@@ -223,14 +246,14 @@ settings_key = "translations"
 [node name="TranslationIdSettings" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 8 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_top = 298.0
+margin_top = 326.0
 margin_right = 398.0
-margin_bottom = 352.0
+margin_bottom = 380.0
 
 [node name="VBoxContainer3" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
-margin_top = 462.0
+margin_top = 490.0
 margin_right = 398.0
-margin_bottom = 512.0
+margin_bottom = 540.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer3" instance=ExtResource( 2 )]
 margin_right = 398.0
@@ -247,9 +270,9 @@ settings_section = "saving"
 settings_key = "autosave"
 
 [node name="VBoxContainer4" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
-margin_top = 528.0
+margin_top = 556.0
 margin_right = 398.0
-margin_bottom = 606.0
+margin_bottom = 634.0
 
 [node name="SectionTitle2" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4" instance=ExtResource( 2 )]
 margin_right = 398.0
@@ -315,7 +338,7 @@ value = 0.5
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3"]
 margin_left = 402.0
 margin_right = 708.0
-margin_bottom = 606.0
+margin_bottom = 634.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2"]
 margin_right = 306.0

--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
@@ -160,7 +160,6 @@ margin_right = 398.0
 margin_bottom = 190.0
 hint_tooltip = "Re-center portrait on each change (1.4+ behavior)"
 text = "Multithreaded image loading"
-default = true
 settings_section = "dialog"
 settings_key = "threading_enabled"
 

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -1361,6 +1361,8 @@ func grab_portrait_focus(character_data, event: Dictionary = {}) -> bool:
 			portrait.focus()
 			emit_signal("portrait_changed", portrait)
 			if event.has('portrait'):
+				if DialogicUtil.can_use_threading() and portrait.get_loading_portrait() != null:
+					yield(portrait, "portrait_image_updated")
 				portrait.set_portrait(get_portrait_name(event))
 				if DialogicUtil.can_use_threading():
 					yield(portrait, "portrait_image_updated")

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -731,6 +731,8 @@ func event_handler(event: Dictionary):
 					var char_portrait = get_portrait_name(event)
 					p.init(char_portrait)
 					p.set_mirror(event.get('mirror_portrait', false))
+					if DialogicUtil.can_use_threading():
+						yield(p, 'portrait_image_updated')
 					
 					# ADD IT TO THE SCENE
 					$Portraits.add_child(p)
@@ -774,6 +776,8 @@ func event_handler(event: Dictionary):
 								var portrait_name = get_portrait_name(event)
 								if portrait_name != portrait.current_state['portrait']:
 									portrait.set_portrait(portrait_name)
+									if DialogicUtil.can_use_threading():
+										yield(portrait, "portrait_image_updated")
 									# recalculate the position of the portrait with an instant animation
 									portrait.move_to_position(get_character_position(portrait.current_state['position']))
 								
@@ -1358,6 +1362,8 @@ func grab_portrait_focus(character_data, event: Dictionary = {}) -> bool:
 			emit_signal("portrait_changed", portrait)
 			if event.has('portrait'):
 				portrait.set_portrait(get_portrait_name(event))
+				if DialogicUtil.can_use_threading():
+					yield(portrait, "portrait_image_updated")
 				if settings.get_value('dialog', 'recenter_portrait', true):
 					portrait.move_to_position(portrait.direction)
 		else:
@@ -1581,6 +1587,8 @@ func resume_state_from_info(state_info):
 			p.dim_time = current_theme.get_value('animation', 'dim_time', 0.5)
 			p.character_data = character_data
 			p.init(char_portrait)
+			if DialogicUtil.can_use_threading():
+				yield(p, "portrait_image_updated")
 
 			p.set_mirror(event.get('mirror', false))
 			$Portraits.add_child(p)

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -341,12 +341,17 @@ func load_theme(filename):
 		return current_theme 
 	var theme = load_theme
 	current_theme_file_name = filename
-	# Box size
-	call_deferred('deferred_resize', $TextBubble.rect_size, theme.get_value('box', 'size', Vector2(910, 167)), current_theme_anchor)
 	
-	if DialogicUtil.can_use_threading() and !$TextBubble.is_connected("theme_loaded", self, "set"):
+	# Load the theme and resize/relocate the text bubble after the theme is loaded
+	if !$TextBubble.is_connected("theme_loaded", self, "set"):
 		$TextBubble.connect("theme_loaded", self, "set", ["_theme_loaded", true], CONNECT_ONESHOT)
 	$TextBubble.load_theme(theme)
+	if !_theme_loaded:
+		$TextBubble.connect("theme_loaded", self, "deferred_resize",
+							[$TextBubble.rect_size, theme.get_value('box', 'size', Vector2(910, 167)), current_theme_anchor],
+							CONNECT_ONESHOT)
+	else:
+		deferred_resize($TextBubble.rect_size, theme.get_value('box', 'size', Vector2(910, 167)), current_theme_anchor)
 	HistoryTimeline.change_theme(theme)
 	$DefinitionInfo.load_theme(theme)
 	

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -100,6 +100,10 @@ signal portrait_changed(portrait_path)
 ## 						SCRIPT
 ## -----------------------------------------------------------------------------
 func _ready():
+	# In case the theme takes a while to load, grab the UI focus until the TextBubble is ready
+	focus_mode = FOCUS_ALL
+	grab_focus()
+	
 	# Set this dialog as the latest (used for saving)
 	Engine.get_main_loop().set_meta('latest_dialogic_node', self)
 	# Loading the config files
@@ -149,6 +153,8 @@ func _ready():
 	else:
 		if do_fade_in: _hide_dialog()
 		_init_dialog()
+	
+	focus_mode = FOCUS_NONE
 
 
 # loads the definitions, themes and settings
@@ -346,7 +352,7 @@ func load_theme(filename):
 	if !$TextBubble.is_connected("theme_loaded", self, "set"):
 		$TextBubble.connect("theme_loaded", self, "set", ["_theme_loaded", true], CONNECT_ONESHOT)
 	$TextBubble.load_theme(theme)
-	if !_theme_loaded:
+	if !_theme_loaded and !$TextBubble.is_connected("theme_loaded", self, "deferred_resize"):
 		$TextBubble.connect("theme_loaded", self, "deferred_resize",
 							[$TextBubble.rect_size, theme.get_value('box', 'size', Vector2(910, 167)), current_theme_anchor],
 							CONNECT_ONESHOT)
@@ -494,11 +500,11 @@ func _input(event: InputEvent) -> void:
 					$FX/CharacterVoice.stop_voice() # stop the current voice as well
 					play_audio("passing")
 					_load_next_event()
-				else:
+				elif !dialog_script.empty():
 					next_event(false)
 			if settings.has_section_key('dialog', 'propagate_input'):
 				var propagate_input: bool = settings.get_value('dialog', 'propagate_input')
-				if not propagate_input  and not is_state(state.WAITING_INPUT):
+				if not propagate_input and not is_state(state.WAITING_INPUT):
 					get_tree().set_input_as_handled()
 
 func next_event(discreetly: bool):
@@ -692,8 +698,12 @@ func event_handler(event: Dictionary):
 				grab_portrait_focus(character_data, event)
 				if character_data.get('data', {}).get('theme', '') and current_theme_file_name != character_data.get('data', {}).get('theme', ''):
 					current_theme = load_theme(character_data.get('data', {}).get('theme', ''))
-				elif !character_data.get('data', {}).get('theme', '') and current_default_theme and  current_theme_file_name != current_default_theme:
+					if DialogicUtil.can_use_threading() and !_theme_loaded:
+						yield($TextBubble, "theme_loaded")
+				elif !character_data.get('data', {}).get('theme', '') and current_default_theme and current_theme_file_name != current_default_theme:
 					current_theme = load_theme(current_default_theme)
+					if DialogicUtil.can_use_threading() and !_theme_loaded:
+						yield($TextBubble, "theme_loaded")
 				update_name(character_data)
 
 			#voice 
@@ -1366,6 +1376,7 @@ func grab_portrait_focus(character_data, event: Dictionary = {}) -> bool:
 			portrait.focus()
 			emit_signal("portrait_changed", portrait)
 			if event.has('portrait'):
+				# If this portrait is currently loading an image, wait until it's done
 				if DialogicUtil.can_use_threading() and portrait.get_loading_portrait() != null:
 					yield(portrait, "portrait_image_updated")
 				portrait.set_portrait(get_portrait_name(event))

--- a/addons/dialogic/Nodes/Portrait.gd
+++ b/addons/dialogic/Nodes/Portrait.gd
@@ -20,6 +20,7 @@ var custom_instance : Node2D = null
 var current_state := {'character':'', 'portrait':'', 'position':'', 'mirrored':false}
 
 var _loading_portrait = null	# Threading
+var mutex := Mutex.new()
 
 signal animation_finished()
 signal portrait_image_updated()
@@ -65,25 +66,19 @@ func set_portrait(expression: String) -> void:
 				custom_instance.name = 'DialogicCustomPortraitScene'
 				add_child(custom_instance)
 				
-				$TextureRect.texture = ImageTexture.new()
-				# Threading: use deferred call, otherwise signal will be emitted before
-				# signal is yielded from calling function
-				_loading_portrait = null
-				call_deferred("emit_signal", "portrait_image_updated")
+				_set_portrait_texture(ImageTexture.new())
 				return
 			else:
 				# Creating an image portrait
 				if ResourceLoader.exists(p['path']):
 					if DialogicUtil.can_use_threading():
 						var loader = preload("res://addons/dialogic/Other/threaded_image_loader.gd").new()
-						loader.connect("resource_loaded", self, "_set_portrait_texture", [], CONNECT_ONESHOT | CONNECT_DEFERRED)
+						loader.connect("resource_loaded", self, "_set_portrait_texture", [], CONNECT_ONESHOT)
 						loader.load_resource(p['path'])
 					else:
-						$TextureRect.texture = load(p['path'])
+						_set_portrait_texture(load(p['path']))
 				else:
-					$TextureRect.texture = ImageTexture.new()
-					_loading_portrait = null
-					call_deferred("emit_signal", "portrait_image_updated")
+					_set_portrait_texture(ImageTexture.new())
 				return
 		
 		# Saving what the default is to fallback to it.
@@ -100,30 +95,31 @@ func set_portrait(expression: String) -> void:
 		custom_instance.name = 'DialogicCustomPortraitScene'
 		add_child(custom_instance)
 		
-		$TextureRect.texture = ImageTexture.new()
-		_loading_portrait = null
-		call_deferred("emit_signal", "portrait_image_updated")
+		_set_portrait_texture(ImageTexture.new())
 		return
 	else:
 		# Creating an image portrait
 		if ResourceLoader.exists(default):
 			if DialogicUtil.can_use_threading():
 				var loader = preload("res://addons/dialogic/Other/threaded_image_loader.gd").new()
-				loader.connect("resource_loaded", self, "_set_portrait_texture", [], CONNECT_ONESHOT | CONNECT_DEFERRED)
+				loader.connect("resource_loaded", self, "_set_portrait_texture", [], CONNECT_ONESHOT)
 				loader.load_resource(default)
 			else:
-				$TextureRect.texture = load(default)
+				_set_portrait_texture(load(default))
 		else:
-			$TextureRect.texture = ImageTexture.new()
-			_loading_portrait = null
-			call_deferred("emit_signal", "portrait_image_updated")
+			_set_portrait_texture(ImageTexture.new())
 		return
 
 
 func _set_portrait_texture(tex):
+	# Ensure only 1 thread can set the texture at a time
+	mutex.lock()
 	$TextureRect.texture = tex
+	mutex.unlock()
 	_loading_portrait = null
-	emit_signal("portrait_image_updated")
+	# Threading: use deferred call, otherwise signal may be emitted before
+	# the signal is yielded from the calling function
+	call_deferred("emit_signal", "portrait_image_updated")
 
 
 func get_loading_portrait() -> String:

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -24,8 +24,8 @@ static func prepare():
 	Engine.get_main_loop().set_meta('dialogic_tree', flat_structure)
 	
 	var settings = DialogicResources.get_settings_config()
-	if settings.get_value('dialog', 'do_preload_node', true):
-		var scene = load(settings.get_value('dialog', 'preload_node', "res://addons/dialogic/Nodes/DialogNode.tscn"))
+	if settings.get_value('dialog', 'do_cache_dialognode', true):
+		var scene = load(settings.get_value('dialog', 'cached_dialognode', "res://addons/dialogic/Nodes/DialogNode.tscn"))
 		Engine.get_main_loop().set_meta('dialogic_scene_cache', [scene])
 
 

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -11,6 +11,7 @@ extends Node
 class_name Dialogic
 
 ## Preloader function, loads and prepares the tree into the Engine meta
+## Additionally will create DialogNode cache if configured in settings
 ## Not necessary to run separately, it will be run by Dialogic.start() the first time if it's not present
 ## But useful to speed up loading
 ## This might be slower than the older way, though, so best to do with some other loading
@@ -21,6 +22,11 @@ static func prepare():
 	var flat_structure = DialogicUtil.get_flat_folders_list(false) 
 
 	Engine.get_main_loop().set_meta('dialogic_tree', flat_structure)
+	
+	var settings = DialogicResources.get_settings_config()
+	if settings.get_value('dialog', 'do_preload_node', true):
+		var scene = load(settings.get_value('dialog', 'preload_node', "res://addons/dialogic/Nodes/DialogNode.tscn"))
+		Engine.get_main_loop().set_meta('dialogic_scene_cache', [scene])
 
 
 ## Starts the dialog for the given timeline and returns a Dialog node.
@@ -49,6 +55,10 @@ static func start(timeline: String = '', default_timeline: String ='', dialog_sc
 	
 	if !Engine.get_main_loop().has_meta('dialogic_tree'):
 		prepare()
+	if Engine.get_main_loop().has_meta('dialogic_scene_cache'):
+		var sc = Engine.get_main_loop().get_meta('dialogic_scene_cache')
+		if !sc.has(dialog_scene):
+			sc.append(dialog_scene)
 	
 	if use_canvas_instead:
 		var canvas_dialog_script = load("res://addons/dialogic/Nodes/canvas_dialog_node.gd")

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -22,6 +22,7 @@ static func prepare():
 	var flat_structure = DialogicUtil.get_flat_folders_list(false) 
 
 	Engine.get_main_loop().set_meta('dialogic_tree', flat_structure)
+	Engine.get_main_loop().set_meta('dialogic_settings', DialogicResources.get_settings_config())
 	
 	var settings = DialogicResources.get_settings_config()
 	if settings.get_value('dialog', 'do_cache_dialognode', true):

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -92,7 +92,12 @@ static func start(timeline: String = '', default_timeline: String ='', dialog_sc
 	
 	# check if it's a file name
 	if timeline.ends_with('.json'):
-		for t in Engine.get_main_loop().get_meta('dialogic_tree')['Timelines'].values():
+		var loop_over
+		if Engine.editor_hint:
+			loop_over = DialogicUtil.get_timeline_list()
+		else:
+			loop_over = Engine.get_main_loop().get_meta('dialogic_tree')['Timelines'].values()
+		for t in loop_over:
 			if t['file'] == timeline:
 				dialog_node.timeline = t['file']
 				dialog_node.timeline_name = timeline

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -56,7 +56,7 @@ static func start(timeline: String = '', default_timeline: String ='', dialog_sc
 	
 	if !Engine.get_main_loop().has_meta('dialogic_tree'):
 		prepare()
-	if Engine.get_main_loop().has_meta('dialogic_scene_cache'):
+	if Engine.get_main_loop().has_meta('dialogic_scene_cache') and DialogicResources.get_settings_value('dialog', 'do_cache_dialognode', true):
 		var sc = Engine.get_main_loop().get_meta('dialogic_scene_cache')
 		if !sc.has(dialog_scene):
 			sc.append(dialog_scene)

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -92,7 +92,7 @@ static func start(timeline: String = '', default_timeline: String ='', dialog_sc
 	
 	# check if it's a file name
 	if timeline.ends_with('.json'):
-		for t in DialogicUtil.get_timeline_list():
+		for t in Engine.get_main_loop().get_meta('dialogic_tree')['Timelines'].values():
 			if t['file'] == timeline:
 				dialog_node.timeline = t['file']
 				dialog_node.timeline_name = timeline

--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -174,6 +174,8 @@ static func copy_file(path_from, path_to):
 ##							CONFIG
 ## *****************************************************************************
 static func get_config(id: String) -> ConfigFile:
+	if !Engine.editor_hint and Engine.get_main_loop().has_meta('dialogic_settings'):
+		return Engine.get_main_loop().get_meta('dialogic_settings')
 	var paths := get_config_files_paths()
 	var config := ConfigFile.new()
 	if id in paths.keys():

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -903,7 +903,8 @@ static func get_flat_folders_list(include_folders: bool = true) -> Dictionary:
 
 
 static func can_use_threading() -> bool:
-	return !Engine.editor_hint and !OS.has_feature('HTML5')
+	var settings = DialogicResources.get_settings_config()
+	return !Engine.editor_hint and !OS.has_feature('HTML5') and settings.get_value("dialog", 'threading_enabled', true)
 
 ## *****************************************************************************
 ##							DIALOGIC_SORTER CLASS

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -15,6 +15,8 @@ static func list_to_dict(list):
 ## *****************************************************************************
 
 static func get_character_list() -> Array:
+	if !Engine.editor_hint and Engine.get_main_loop().has_meta('dialogic_tree'):
+		return Engine.get_main_loop().get_meta('dialogic_tree')['Characters'].values()
 	var characters: Array = []
 	for file in DialogicResources.listdir(DialogicResources.get_path('CHAR_DIR')):
 		if '.json' in file:
@@ -57,6 +59,8 @@ static func get_character(character_id):
 
 
 static func get_timeline_list() -> Array:
+	if !Engine.editor_hint and Engine.get_main_loop().has_meta('dialogic_tree'):
+		return Engine.get_main_loop().get_meta('dialogic_tree')['Timelines'].values()
 	var timelines: Array = []
 	for file in DialogicResources.listdir(DialogicResources.get_path('TIMELINE_DIR')):
 		if '.json' in file: # TODO check for real .json because if .json is in the middle of the sentence it still thinks it is a timeline
@@ -87,6 +91,8 @@ static func get_sorted_timeline_list():
 ## *****************************************************************************
 
 static func get_theme_list() -> Array:
+	if !Engine.editor_hint and Engine.get_main_loop().has_meta('dialogic_tree'):
+		return Engine.get_main_loop().get_meta('dialogic_tree')['Themes'].values()
 	var themes: Array = []
 	for file in DialogicResources.listdir(DialogicResources.get_path('THEME_DIR')):
 		if '.cfg' in file:

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -606,6 +606,21 @@ static func compare_dicts(dict_1: Dictionary, dict_2: Dictionary) -> bool:
 	return false
 
 
+static func path_fixer(path):
+	match path:
+		'res://addons/dialogic/Fonts/DefaultFont.tres':
+			return "res://addons/dialogic/Example Assets/Fonts/DefaultFont.tres"
+		'res://addons/dialogic/Fonts/GlossaryFont.tres':
+			return 'res://addons/dialogic/Example Assets/Fonts/GlossaryFont.tres'
+		'res://addons/dialogic/Images/background/background-1.png':
+			return 'res://addons/dialogic/Example Assets/backgrounds/background-1.png'
+		'res://addons/dialogic/Images/background/background-2.png':
+			return 'res://addons/dialogic/Example Assets/backgrounds/background-2.png'
+		'res://addons/dialogic/Images/next-indicator.png':
+			return 'res://addons/dialogic/Example Assets/next-indicator/next-indicator.png'
+
+	return path
+
 static func path_fixer_load(path):
 	# This function was added because some of the default assets shipped with
 	# Dialogic 1.0 were moved for version 1.1. If by any chance they still
@@ -614,19 +629,7 @@ static func path_fixer_load(path):
 	# DialogicUtil.path_fixer_load(x) with just load(x) on version 2.0
 	# since we will break compatibility.
 	
-	match path:
-		'res://addons/dialogic/Fonts/DefaultFont.tres':
-			return load("res://addons/dialogic/Example Assets/Fonts/DefaultFont.tres")
-		'res://addons/dialogic/Fonts/GlossaryFont.tres':
-			return load('res://addons/dialogic/Example Assets/Fonts/GlossaryFont.tres')
-		'res://addons/dialogic/Images/background/background-1.png':
-			return load('res://addons/dialogic/Example Assets/backgrounds/background-1.png')
-		'res://addons/dialogic/Images/background/background-2.png':
-			return load('res://addons/dialogic/Example Assets/backgrounds/background-2.png')
-		'res://addons/dialogic/Images/next-indicator.png':
-			return load('res://addons/dialogic/Example Assets/next-indicator/next-indicator.png')
-
-	return load(path)
+	return load(path_fixer(path))
 
 # This function contains necessary updates.
 # This should be deleted in 2.0
@@ -898,6 +901,9 @@ static func get_flat_folders_list(include_folders: bool = true) -> Dictionary:
 	
 	return flatten
 
+
+static func can_use_threading() -> bool:
+	return !Engine.editor_hint and !OS.has_feature('HTML5')
 
 ## *****************************************************************************
 ##							DIALOGIC_SORTER CLASS

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -904,7 +904,7 @@ static func get_flat_folders_list(include_folders: bool = true) -> Dictionary:
 
 static func can_use_threading() -> bool:
 	var settings = DialogicResources.get_settings_config()
-	return !Engine.editor_hint and !OS.has_feature('HTML5') and settings.get_value("dialog", 'threading_enabled', true)
+	return !Engine.editor_hint and !OS.has_feature('HTML5') and settings.get_value("dialog", 'threading_enabled', false)
 
 ## *****************************************************************************
 ##							DIALOGIC_SORTER CLASS

--- a/addons/dialogic/Other/threaded_image_loader.gd
+++ b/addons/dialogic/Other/threaded_image_loader.gd
@@ -1,0 +1,39 @@
+extends Reference
+
+
+signal resource_loaded(res)
+
+var thread: Thread = null
+
+func _init():
+	# Make sure the there is a reference to this object so we can keep the thread alive
+	reference()
+	thread = Thread.new()
+
+func load_resource(path):
+	var state = thread.start(self, "_thread_load", path)
+	if state != OK:
+		print("Error while starting thread: " + str(state))
+		thread.wait_to_finish()
+		unreference()
+
+func _thread_load(path):
+	var ril = ResourceLoader.load_interactive(path)
+	var res = null
+
+	while true:
+		var err = ril.poll()
+		if err == ERR_FILE_EOF:
+			res = ril.get_resource()
+			break
+		elif err != OK:
+			print("There was an error loading")
+			break
+	assert(res)
+	emit_signal("resource_loaded", res)
+	call_deferred("_thread_done")
+
+func _thread_done():
+	# Wait for the thread to finish before removing it
+	thread.wait_to_finish()
+	unreference()

--- a/addons/dialogic/Parser/DialogicParser.gd
+++ b/addons/dialogic/Parser/DialogicParser.gd
@@ -4,7 +4,11 @@ class_name DialogicParser
 
 # adds name coloring to the dialog texts
 static func parse_characters(dialog_script):
-	var characters = DialogicUtil.get_character_list()
+	var characters
+	if Engine.editor_hint:
+		characters = DialogicUtil.get_character_list()
+	else:
+		characters = Engine.get_main_loop().get_meta('dialogic_tree', [])['Characters'].values()
 	var event_index := 0
 	for event in dialog_script['events']:
 		# if this is a text or question event


### PR DESCRIPTION
This PR addresses some causes of stuttering that happens when starting a timeline. Changes include:

1. Keep a cached version of `DialogNode.tscn` or whatever node the user has chosen. This allows `ResourceLoader` to have a cached version in memory so it doesn't have to load it from the disk every time. The cache is created during the `Dialogic.preload()` call (Optional, includes a setting to enable & pick cached scene).
2. Using the built-in timeline cache when loading a timeline from its filename on disk (`timeline-xxxx.json`). It seems like this may have been a simple oversight originally, but it was causing every timeline to be loaded from the disk for me because I was using custom resources with an exported value that used the custom timeline selector.
3. Multi-threaded image loading for themes and portraits. This is probably the biggest stutter reduction but also has the highest risk of breaking things. Threading is automatically disabled in the editor and on web exports, and there is an additional setting to turn it off for other exports.

My changes seem to work fine in my use/testing, but I haven't tested it extensively with very many use cases. I tested on Windows/Linux/Web builds, Godot 3.5.3, i7-11700KF, RX6800XT.